### PR TITLE
Allow metadata in streams

### DIFF
--- a/Template/ClientCPP.tt
+++ b/Template/ClientCPP.tt
@@ -17,16 +17,31 @@ foreach(GrpcService service in s.ServiceArray)
 foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
-FGrpcContextHandle U<#=service.Name#>Client::Init<#=method.Name#>()
+
+<#if (method.ClientStreaming){#>
+FGrpcContextHandle U<#= service.Name #>Client::Create<#= method.Name #>()
+<#}else{#>
+FGrpcContextHandle U<#= service.Name #>Client::Init<#= method.Name #>()
+<#}#>
 {
+
 	FGrpcContextHandle handle = Service->TurboLinkManager->GetNextContextHandle();
 	auto context = UGrpcClient::MakeContext<GrpcContext_<#=service.Name#>_<#=method.Name#>>(handle);
 	context->RpcContext = UTurboLinkGrpcManager::Private::CreateRpcClientContext();
-<#if(method.ClientStreaming) {#>
-	context->Init();
-<#}#>
 	return context->GetHandle();
 }
+
+<#if(method.ClientStreaming) {#>
+void U<#= service.Name #>Client::Init<#= method.Name #>FromHandle(FGrpcContextHandle Handle)
+{
+	auto context = UGrpcClient::GetContext(Handle);
+	if (context != nullptr)
+	{
+		auto context<#=method.Name#> = StaticCastSharedPtr<GrpcContext_<#=service.Name#>_<#=method.Name#>>(*context);
+		context<#=method.Name#>->Init();
+	}
+}
+<#}#>
 
 void U<#=service.Name#>Client::<#=method.Name#>(FGrpcContextHandle Handle, const <#=method.InputType#>& Request)
 {

--- a/Template/ClientCPP.tt
+++ b/Template/ClientCPP.tt
@@ -17,11 +17,19 @@ foreach(GrpcService service in s.ServiceArray)
 foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
-<#if (method.ClientStreaming){#>
-FGrpcContextHandle U<#= service.Name #>Client::Create<#= method.Name #>()
-<#}else{#>
-FGrpcContextHandle U<#= service.Name #>Client::Init<#= method.Name #>()
+FGrpcContextHandle U<#=service.Name#>Client::Init<#=method.Name#>()
+{
+	FGrpcContextHandle handle = Service->TurboLinkManager->GetNextContextHandle();
+	auto context = UGrpcClient::MakeContext<GrpcContext_<#=service.Name#>_<#=method.Name#>>(handle);
+	context->RpcContext = UTurboLinkGrpcManager::Private::CreateRpcClientContext();
+<#if(method.ClientStreaming) {#>
+	context->Init();
 <#}#>
+	return context->GetHandle();
+}
+
+<#if (method.ClientStreaming){#>
+FGrpcContextHandle U<#=service.Name#>Client::Create<#=method.Name#>()
 {
 	FGrpcContextHandle handle = Service->TurboLinkManager->GetNextContextHandle();
 	auto context = UGrpcClient::MakeContext<GrpcContext_<#=service.Name#>_<#=method.Name#>>(handle);
@@ -29,8 +37,7 @@ FGrpcContextHandle U<#= service.Name #>Client::Init<#= method.Name #>()
 	return context->GetHandle();
 }
 
-<#if(method.ClientStreaming) {#>
-void U<#= service.Name #>Client::Init<#= method.Name #>FromHandle(FGrpcContextHandle Handle)
+void U<#=service.Name#>Client::Init<#=method.Name#>FromHandle(FGrpcContextHandle Handle)
 {
 	auto context = UGrpcClient::GetContext(Handle);
 	if (context != nullptr)

--- a/Template/ClientCPP.tt
+++ b/Template/ClientCPP.tt
@@ -17,14 +17,12 @@ foreach(GrpcService service in s.ServiceArray)
 foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
-
 <#if (method.ClientStreaming){#>
 FGrpcContextHandle U<#= service.Name #>Client::Create<#= method.Name #>()
 <#}else{#>
 FGrpcContextHandle U<#= service.Name #>Client::Init<#= method.Name #>()
 <#}#>
 {
-
 	FGrpcContextHandle handle = Service->TurboLinkManager->GetNextContextHandle();
 	auto context = UGrpcClient::MakeContext<GrpcContext_<#=service.Name#>_<#=method.Name#>>(handle);
 	context->RpcContext = UTurboLinkGrpcManager::Private::CreateRpcClientContext();

--- a/Template/ClientH.tt
+++ b/Template/ClientH.tt
@@ -56,15 +56,16 @@ public:
 foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
+	UFUNCTION(BlueprintCallable, Category = TurboLink)
+	FGrpcContextHandle Init<#=method.Name#>();
+
 <#if (method.ClientStreaming){#>
+	//Use Create -> InitFromHandle instead of Init if you want to add metadata to a stream
 	UFUNCTION(BlueprintCallable, Category = TurboLink)
 	FGrpcContextHandle Create<#=method.Name#>();
 
 	UFUNCTION(BlueprintCallable, Category = TurboLink)
-	void Init<#=method.Name#>FromHandle(FGrpcContextHandle Handle);
-<#}else{#>
-	UFUNCTION(BlueprintCallable, Category = TurboLink)
-	FGrpcContextHandle Init<#=method.Name#>();
+	void Init<#=method.Name#>FromHandle(FGrpcContextHandle Handle);	
 <#}#>
 
 	UFUNCTION(BlueprintCallable, Category = TurboLink)

--- a/Template/ClientH.tt
+++ b/Template/ClientH.tt
@@ -56,12 +56,14 @@ public:
 foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
-	UFUNCTION(BlueprintCallable, Category = TurboLink)
-
 <#if (method.ClientStreaming){#>
+	UFUNCTION(BlueprintCallable, Category = TurboLink)
 	FGrpcContextHandle Create<#=method.Name#>();
+
+	UFUNCTION(BlueprintCallable, Category = TurboLink)
 	void Init<#=method.Name#>FromHandle(FGrpcContextHandle Handle);
 <#}else{#>
+	UFUNCTION(BlueprintCallable, Category = TurboLink)
 	FGrpcContextHandle Init<#=method.Name#>();
 <#}#>
 

--- a/Template/ClientH.tt
+++ b/Template/ClientH.tt
@@ -57,7 +57,13 @@ foreach (GrpcServiceMethod method in service.MethodArray)
 {
 #>
 	UFUNCTION(BlueprintCallable, Category = TurboLink)
+
+<#if (method.ClientStreaming){#>
+	FGrpcContextHandle Create<#=method.Name#>();
+	void Init<#=method.Name#>FromHandle(FGrpcContextHandle Handle);
+<#}else{#>
 	FGrpcContextHandle Init<#=method.Name#>();
+<#}#>
 
 	UFUNCTION(BlueprintCallable, Category = TurboLink)
 	void <#=method.Name#>(FGrpcContextHandle Handle, const <#=method.InputType#>& Request);


### PR DESCRIPTION
Previously, we were unable to add auth metadata for client streaming due to `context->Init()` being called in the `<service>Client::Init<method>` templated function which needs to happen after we have added metadata to the context.

Fixed by:
- Templating a Create function for Client Streaming identical to non-streaming Init template function
- Removing `context->Init()` from `<service>Client::Init<method>` templated function
- Add a `Init<method.Name>FromHandle` function for client streaming to allow deferred `context->Init()` call after metadata has been added